### PR TITLE
Fix light mode + persist preferences

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -42,13 +42,6 @@ const MarketCoverage = React.lazy(() => import('./pages/MarketCoverage'));
 const MarketTracked = React.lazy(() => import('./pages/MarketTracked'));
 const AdminRunbook = React.lazy(() => import('./pages/AdminRunbook'));
 
-const surfacePalette = {
-  dark: {
-    panel: '#182233',
-    border: '#2F4461',
-  },
-};
-
 // Create a client for React Query
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -115,9 +108,9 @@ function App() {
                     position="top-right"
                     toastOptions={{
                       style: {
-                        background: surfacePalette.dark.panel,
-                        color: '#F7F9FC',
-                        border: `1px solid ${surfacePalette.dark.border}`,
+                        background: 'var(--chakra-colors-bg-panel)',
+                        color: 'var(--chakra-colors-fg-default)',
+                        border: '1px solid var(--chakra-colors-border-subtle)',
                       },
                     }}
                   />

--- a/frontend/src/components/SortableTable.tsx
+++ b/frontend/src/components/SortableTable.tsx
@@ -14,6 +14,7 @@ import {
 } from '@chakra-ui/react';
 import { FiChevronUp, FiChevronDown, FiMinus } from 'react-icons/fi';
 import EmptyState from './ui/EmptyState';
+import { useUserPreferences } from '../hooks/useUserPreferences';
 
 export interface Column<T = any> {
   key: string;
@@ -43,12 +44,14 @@ function SortableTable<T = any>({
   columns,
   defaultSortBy,
   defaultSortOrder = 'desc',
-  size = 'md',
+  size: sizeProp,
   variant = 'simple',
   showHeader = true,
   emptyMessage = 'No data available',
   maxHeight,
 }: SortableTableProps<T>) {
+  const { tableDensity } = useUserPreferences();
+  const size: 'sm' | 'md' | 'lg' = sizeProp ?? (tableDensity === 'compact' ? 'sm' : 'md');
   const [sortBy, setSortBy] = useState<string>(defaultSortBy || columns[0]?.key || '');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>(defaultSortOrder);
 

--- a/frontend/src/components/__tests__/SortableTableDensity.test.tsx
+++ b/frontend/src/components/__tests__/SortableTableDensity.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders } from '../../test/render';
+import SortableTable, { type Column } from '../SortableTable';
+
+// Keep most Chakra exports real, but replace table primitives so we can assert `size`.
+vi.mock('@chakra-ui/react', async () => {
+  const actual: any = await vi.importActual('@chakra-ui/react');
+  return {
+    ...actual,
+    TableScrollArea: ({ children }: any) => <div>{children}</div>,
+    TableRoot: ({ children, size, ...rest }: any) => (
+      <table data-testid="table-root" data-size={size} {...rest}>
+        {children}
+      </table>
+    ),
+    TableHeader: ({ children }: any) => <thead>{children}</thead>,
+    TableBody: ({ children }: any) => <tbody>{children}</tbody>,
+    // Drop Chakra-style props like `textAlign`/`borderColor` to avoid React warnings in this test.
+    TableRow: ({ children }: any) => <tr>{children}</tr>,
+    TableColumnHeader: ({ children, onClick }: any) => <th onClick={onClick}>{children}</th>,
+    TableCell: ({ children }: any) => <td>{children}</td>,
+  };
+});
+
+vi.mock('../../hooks/useUserPreferences', () => ({
+  useUserPreferences: () => ({
+    currency: 'USD',
+    timezone: 'UTC',
+    tableDensity: 'compact',
+  }),
+}));
+
+describe('SortableTable table density default', () => {
+  it('defaults to size="sm" when user table_density is compact and size prop is not set', () => {
+    const columns: Column<any>[] = [
+      { key: 'name', header: 'Name', accessor: (r) => r.name },
+    ];
+    const { getByTestId } = renderWithProviders(<SortableTable data={[{ name: 'A' }]} columns={columns} />);
+    expect(getByTestId('table-root')).toHaveAttribute('data-size', 'sm');
+  });
+
+  it('respects explicit size prop even when user table_density is compact', () => {
+    const columns: Column<any>[] = [
+      { key: 'name', header: 'Name', accessor: (r) => r.name },
+    ];
+    const { getAllByTestId } = renderWithProviders(<SortableTable data={[{ name: 'A' }]} columns={columns} size="lg" />);
+    const tables = getAllByTestId('table-root');
+    expect(tables.some((t) => t.getAttribute('data-size') === 'lg')).toBe(true);
+  });
+});
+
+

--- a/frontend/src/components/layout/DashboardLayout.tsx
+++ b/frontend/src/components/layout/DashboardLayout.tsx
@@ -72,11 +72,11 @@ interface NavItemProps {
 }
 
 const NavItem: React.FC<NavItemProps> = ({ icon: Icon, label, isActive, onClick, badge, showLabel = true }) => {
-  const bg = 'gray.800';
-  const activeBg = 'gray.700';
-  const activeColor = 'white';
-  const color = 'gray.300';
-  const hoverColor = 'white';
+  const hoverBg = 'bg.muted';
+  const activeBg = 'bg.subtle';
+  const activeColor = 'fg.default';
+  const color = 'fg.muted';
+  const hoverColor = 'fg.default';
 
   return (
     <Flex
@@ -92,7 +92,7 @@ const NavItem: React.FC<NavItemProps> = ({ icon: Icon, label, isActive, onClick,
       bg={isActive ? activeBg : 'transparent'}
       color={isActive ? activeColor : color}
       _hover={{
-        bg: isActive ? activeBg : bg,
+        bg: isActive ? activeBg : hoverBg,
         color: isActive ? activeColor : hoverColor,
       }}
       onClick={onClick}
@@ -128,10 +128,10 @@ const NavItem: React.FC<NavItemProps> = ({ icon: Icon, label, isActive, onClick,
 const DashboardLayout: React.FC = () => {
   const location = useLocation();
   const navigate = useNavigate();
-  const sidebarBg = 'gray.900';
-  const headerBg = 'gray.950';
-  const borderColor = 'gray.800';
-  const appBg = 'gray.950';
+  const sidebarBg = 'bg.sidebar';
+  const headerBg = 'bg.header';
+  const borderColor = 'border.subtle';
+  const appBg = 'bg.canvas';
   const { accounts, loading: accountsLoading, selected, setSelected } = useAccountContext();
   const { user, logout } = useAuth();
   const [isSidebarOpen, setIsSidebarOpen] = useState<boolean>(true);
@@ -238,31 +238,31 @@ const DashboardLayout: React.FC = () => {
               <Box px={4} py={4} mt="auto">
                 <VStack gap={2} align="stretch">
                   <HStack justify="space-between">
-                    <Text fontSize="xs" fontWeight="semibold" color="gray.500">
+                    <Text fontSize="xs" fontWeight="semibold" color="fg.subtle">
                       {headerStats.label}
                     </Text>
-                    <Text fontSize="xs" fontWeight="semibold" color="gray.200">
+                    <Text fontSize="xs" fontWeight="semibold" color="fg.muted">
                       {headerStats.sublabel || formatSignedCurrency(totals.dayPnL)}
                     </Text>
                   </HStack>
                   <AppDivider />
-                  <Text fontSize="xs" fontWeight="semibold" color="gray.500" textTransform="uppercase">
+                  <Text fontSize="xs" fontWeight="semibold" color="fg.subtle" textTransform="uppercase">
                     Quick Stats
                   </Text>
                   <HStack justify="space-between">
-                    <Text fontSize="xs" color="gray.500">Day P&L</Text>
+                    <Text fontSize="xs" color="fg.subtle">Day P&L</Text>
                     <Text fontSize="xs" fontWeight="semibold" color={totals.dayPnL >= 0 ? 'green.400' : 'red.400'}>
                       {formatSignedCurrency(totals.dayPnL)}
                     </Text>
                   </HStack>
                   <HStack justify="space-between">
-                    <Text fontSize="xs" color="gray.500">Positions</Text>
+                    <Text fontSize="xs" color="fg.subtle">Positions</Text>
                     <Text fontSize="xs" fontWeight="semibold">
                       {totals.positions}
                     </Text>
                   </HStack>
                   <HStack justify="space-between">
-                    <Text fontSize="xs" color="gray.500">Margin Used</Text>
+                    <Text fontSize="xs" color="fg.subtle">Margin Used</Text>
                     <Text fontSize="xs" fontWeight="semibold" color="orange.400">
                       23%
                     </Text>
@@ -332,6 +332,7 @@ const DashboardLayout: React.FC = () => {
               aria-label="Menu"
               position="relative"
               zIndex={2}
+              color="fg.default"
               onClick={() => {
                 if (isDesktop) {
                   setIsSidebarOpen((v) => !v);
@@ -352,9 +353,9 @@ const DashboardLayout: React.FC = () => {
                 fontSize: 12,
                 padding: '6px 8px',
                 borderRadius: 8,
-                border: '1px solid #2d3748',
-                background: '#111827',
-                color: '#e5e7eb',
+                border: '1px solid var(--chakra-colors-border-subtle)',
+                background: 'var(--chakra-colors-bg-input)',
+                color: 'var(--chakra-colors-fg-default)',
               }}
             >
               <option value="all">All Accounts</option>
@@ -370,7 +371,7 @@ const DashboardLayout: React.FC = () => {
           </HStack>
 
           <HStack gap={4}>
-            <IconButton size="md" variant="ghost" aria-label="Notifications" position="relative">
+            <IconButton size="md" variant="ghost" aria-label="Notifications" position="relative" color="fg.default">
               <FiBell />
               <Badge
                 position="absolute"

--- a/frontend/src/components/ui/AccountSelector.tsx
+++ b/frontend/src/components/ui/AccountSelector.tsx
@@ -23,6 +23,8 @@ import {
 } from '@chakra-ui/react';
 import { FiInfo, FiTrendingUp, FiTrendingDown, FiDollarSign } from 'react-icons/fi';
 import AppDivider from './AppDivider';
+import { useUserPreferences } from '../../hooks/useUserPreferences';
+import { formatMoney } from '../../utils/format';
 
 export interface AccountData {
   account_id: string;
@@ -62,6 +64,7 @@ const AccountSelector: React.FC<AccountSelectorProps> = ({
   const bgColor = 'bg.card';
   const borderColor = 'border.subtle';
   const hoverBg = 'bg.panel';
+  const { currency } = useUserPreferences();
 
   // Calculate totals
   const totalValue = accounts.reduce((sum, acc) => sum + acc.total_value, 0);
@@ -70,12 +73,7 @@ const AccountSelector: React.FC<AccountSelectorProps> = ({
   const totalPositions = accounts.reduce((sum, acc) => sum + acc.positions_count, 0);
 
   const formatCurrency = (amount: number) =>
-    new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: 'USD',
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0,
-    }).format(amount || 0);
+    formatMoney(amount || 0, currency, { maximumFractionDigits: 0, minimumFractionDigits: 0 });
 
   const formatPercentage = (pct: number | undefined) => {
     if (pct === undefined || pct === null || Number.isNaN(pct)) return '0.00%';
@@ -99,9 +97,9 @@ const AccountSelector: React.FC<AccountSelectorProps> = ({
           maxWidth: 250,
           padding: '8px 10px',
           borderRadius: 10,
-          border: '1px solid rgba(255,255,255,0.14)',
-          background: 'var(--chakra-colors-bg-input, #0b1220)',
-          color: 'var(--chakra-colors-fg-default, #e5e7eb)',
+          border: '1px solid var(--chakra-colors-border-subtle)',
+          background: 'var(--chakra-colors-bg-input)',
+          color: 'var(--chakra-colors-fg-default)',
           fontSize: 14,
         }}
       >

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -112,4 +112,9 @@ export const useAuth = () => {
   return ctx;
 };
 
+// Optional accessor for non-authenticated contexts (tests, public pages, storybook).
+export const useAuthOptional = () => {
+  return useContext(AuthContext);
+};
+
 

--- a/frontend/src/hooks/useUserPreferences.ts
+++ b/frontend/src/hooks/useUserPreferences.ts
@@ -1,0 +1,23 @@
+import { useMemo } from "react";
+import { useAuthOptional } from "../context/AuthContext";
+
+export type TableDensity = "comfortable" | "compact";
+
+export function useUserPreferences(): {
+  currency: string;
+  timezone: string;
+  tableDensity: TableDensity;
+} {
+  const auth = useAuthOptional();
+  const user = auth?.user ?? null;
+
+  return useMemo(() => {
+    const currency = (user?.currency_preference || "USD").toUpperCase();
+    const timezone = user?.timezone || "UTC";
+    const td = user?.ui_preferences?.table_density;
+    const tableDensity: TableDensity = td === "compact" ? "compact" : "comfortable";
+    return { currency, timezone, tableDensity };
+  }, [user?.currency_preference, user?.timezone, user?.ui_preferences?.table_density]);
+}
+
+

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -4,6 +4,8 @@ import toast from 'react-hot-toast';
 import api from '../services/api';
 import { triggerTaskByName } from '../utils/taskActions';
 import useCoverageSnapshot from '../hooks/useCoverageSnapshot';
+import { useUserPreferences } from '../hooks/useUserPreferences';
+import { formatDateTime } from '../utils/format';
 import {
   CoverageBucketsGrid,
   CoverageKpiGrid,
@@ -12,6 +14,7 @@ import {
 } from '../components/coverage/CoverageSummaryCard';
 
 const AdminDashboard: React.FC = () => {
+  const { timezone } = useUserPreferences();
   const [backfill5mEnabled, setBackfill5mEnabled] = React.useState<boolean>(true);
   const [toggling5m, setToggling5m] = React.useState<boolean>(false);
   const [refreshingCoverage, setRefreshingCoverage] = React.useState<boolean>(false);
@@ -153,7 +156,7 @@ const AdminDashboard: React.FC = () => {
   const fmtLastRun = (key: string) => {
     const raw = (taskStatus || {})[key];
     const ts = raw?.ts;
-    return ts ? new Date(ts).toLocaleString() : '—';
+    return formatDateTime(ts, timezone);
   };
 
   return (
@@ -169,7 +172,7 @@ const AdminDashboard: React.FC = () => {
             <Box>
               <Text fontSize="xs" color="gray.400">
                 Source: <Text as="span" color="gray.200">{String(coverage?.meta?.source || '—')}</Text> •{' '}
-                Last refresh: <Text as="span" color="gray.200">{coverage?.meta?.updated_at ? new Date(coverage.meta.updated_at).toLocaleString() : '—'}</Text>
+                Last refresh: <Text as="span" color="gray.200">{formatDateTime(coverage?.meta?.updated_at, timezone)}</Text>
                 {' '}• Monitor last run:{' '}
                 <Text as="span" color="gray.200">{fmtLastRun('taskstatus:monitor_coverage_health:last')}</Text>
               </Text>

--- a/frontend/src/pages/AdminJobs.tsx
+++ b/frontend/src/pages/AdminJobs.tsx
@@ -25,8 +25,11 @@ import api from '../services/api';
 import { FiInfo } from 'react-icons/fi';
 import Pagination from '../components/ui/Pagination';
 import SortableTable, { type Column } from '../components/SortableTable';
+import { useUserPreferences } from '../hooks/useUserPreferences';
+import { formatDateTime } from '../utils/format';
 
 const AdminJobs: React.FC = () => {
+  const { timezone } = useUserPreferences();
   const [loading, setLoading] = React.useState(false);
   const [data, setData] = React.useState<{ jobs: any[]; total?: number; limit?: number; offset?: number } | null>(null);
   const [selectedJob, setSelectedJob] = React.useState<any | null>(null);
@@ -209,7 +212,7 @@ const AdminJobs: React.FC = () => {
                 sortType: 'date',
                 render: (v) => (
                   <Text fontSize="12px" color="fg.muted">
-                    {v ? new Date(v).toLocaleString() : '—'}
+                    {formatDateTime(v, timezone)}
                   </Text>
                 ),
                 width: '200px',
@@ -222,7 +225,7 @@ const AdminJobs: React.FC = () => {
                 sortType: 'date',
                 render: (v) => (
                   <Text fontSize="12px" color="fg.muted">
-                    {v ? new Date(v).toLocaleString() : '—'}
+                    {formatDateTime(v, timezone)}
                   </Text>
                 ),
                 width: '200px',
@@ -297,10 +300,10 @@ const AdminJobs: React.FC = () => {
                     id: {selectedJob?.id ?? '—'}
                   </Text>
                   <Text fontSize="xs" color="fg.muted">
-                    started: {selectedJob?.started_at ? new Date(selectedJob.started_at).toLocaleString() : '—'}
+                    started: {formatDateTime(selectedJob?.started_at, timezone)}
                   </Text>
                   <Text fontSize="xs" color="fg.muted">
-                    finished: {selectedJob?.finished_at ? new Date(selectedJob.finished_at).toLocaleString() : '—'}
+                    finished: {formatDateTime(selectedJob?.finished_at, timezone)}
                   </Text>
                 </HStack>
 

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -41,6 +41,8 @@ import AccountFilterWrapper from '../components/ui/AccountFilterWrapper';
 import { transformPortfolioToAccounts } from '../hooks/useAccountFilter';
 import AppDivider from '../components/ui/AppDivider';
 import toast from 'react-hot-toast';
+import { useUserPreferences } from '../hooks/useUserPreferences';
+import { formatMoney, formatTime } from '../utils/format';
 
 interface DashboardData {
   total_value: number;
@@ -99,6 +101,7 @@ const Dashboard: React.FC = () => {
   const [syncing, setSyncing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedBrokerage, setSelectedBrokerage] = useState<string>('all');
+  const { currency, timezone } = useUserPreferences();
 
   const cardBg = 'bg.card';
   const borderColor = 'border.subtle';
@@ -153,12 +156,7 @@ const Dashboard: React.FC = () => {
   };
 
   const formatCurrency = (value: number) => {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: 'USD',
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0,
-    }).format(value);
+    return formatMoney(value, currency, { minimumFractionDigits: 0, maximumFractionDigits: 0 });
   };
 
   const formatPercent = (value: number | undefined | null) => {
@@ -222,7 +220,7 @@ const Dashboard: React.FC = () => {
         <Box>
           <Heading size="lg" mb={2}>Portfolio Dashboard</Heading>
           <Text color="gray.500" fontSize="sm">
-            Real-time data from IBKR • Last updated: {new Date(dashboardData.last_updated).toLocaleTimeString()}
+            Real-time data from IBKR • Last updated: {formatTime(dashboardData.last_updated, timezone)}
           </Text>
         </Box>
 

--- a/frontend/src/pages/DividendsCalendar.tsx
+++ b/frontend/src/pages/DividendsCalendar.tsx
@@ -4,10 +4,13 @@ import { FiRefreshCw } from 'react-icons/fi';
 import { useQuery } from 'react-query';
 import SortableTable, { type Column } from '../components/SortableTable';
 import { portfolioApi } from '../services/api';
+import { useUserPreferences } from '../hooks/useUserPreferences';
+import { formatMoney } from '../utils/format';
 
 type DividendRow = any;
 
 const DividendsCalendar: React.FC = () => {
+  const { currency } = useUserPreferences();
   const q = useQuery(['dividends', 365], () => portfolioApi.getDividends(undefined, 365), {
     staleTime: 60_000,
     refetchInterval: 300_000,
@@ -46,7 +49,7 @@ const DividendsCalendar: React.FC = () => {
       isNumeric: true,
       render: (v) => (
         <Text fontSize="12px" color="fg.muted">
-          {Number(v || 0).toLocaleString(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 2 })}
+          {formatMoney(Number(v || 0), currency, { maximumFractionDigits: 2 })}
         </Text>
       ),
       width: '160px',

--- a/frontend/src/pages/MarketTracked.tsx
+++ b/frontend/src/pages/MarketTracked.tsx
@@ -14,8 +14,11 @@ import {
 } from '@chakra-ui/react';
 import toast from 'react-hot-toast';
 import api from '../services/api';
+import { useUserPreferences } from '../hooks/useUserPreferences';
+import { formatDateTime } from '../utils/format';
 
 const MarketTracked: React.FC = () => {
+  const { timezone } = useUserPreferences();
   const [data, setData] = React.useState<any>({ all: [], details: {}, meta: {} });
   const [sortKey, setSortKey] = React.useState<'symbol' | 'market_cap' | 'stage'>('symbol');
   const [sortDir, setSortDir] = React.useState<'asc' | 'desc'>('asc');
@@ -96,7 +99,7 @@ const MarketTracked: React.FC = () => {
                 <TableCell>{fmtCompact(row.market_cap)}</TableCell>
                 <TableCell>{row.stage_label || '—'}</TableCell>
                 <TableCell>{row.atr_value ? row.atr_value.toFixed(2) : '—'}</TableCell>
-                <TableCell>{row.last_snapshot_at ? new Date(row.last_snapshot_at).toLocaleString() : '—'}</TableCell>
+                <TableCell>{formatDateTime(row.last_snapshot_at, timezone)}</TableCell>
                 <TableCell>
                   <Text>{row.sector || '—'}</Text>
                   <Text fontSize="xs" color="gray.500">{row.industry || ''}</Text>

--- a/frontend/src/pages/OptionsPortfolio.tsx
+++ b/frontend/src/pages/OptionsPortfolio.tsx
@@ -3,6 +3,8 @@ import { Box, HStack, Text, Button, Badge, CardRoot, CardBody } from '@chakra-ui
 import { FiRefreshCw } from 'react-icons/fi';
 import { usePortfolio } from '../hooks/usePortfolio';
 import SortableTable, { type Column } from '../components/SortableTable';
+import { useUserPreferences } from '../hooks/useUserPreferences';
+import { formatMoney } from '../utils/format';
 
 type AnyPos = any;
 
@@ -17,6 +19,7 @@ const OptionsPortfolio: React.FC = () => {
   const accounts = Object.values<any>(data?.accounts || {});
   const all: AnyPos[] = accounts.flatMap((a: any) => a?.all_positions || []);
   const options = all.filter(isOptionPosition);
+  const { currency } = useUserPreferences();
 
   const columns: Column<AnyPos>[] = [
     {
@@ -50,7 +53,7 @@ const OptionsPortfolio: React.FC = () => {
       isNumeric: true,
       render: (v) => (
         <Text fontSize="12px" color="fg.muted">
-          {Number(v || 0).toLocaleString(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 0 })}
+          {formatMoney(Number(v || 0), currency, { maximumFractionDigits: 0 })}
         </Text>
       ),
       width: '160px',
@@ -64,7 +67,7 @@ const OptionsPortfolio: React.FC = () => {
       isNumeric: true,
       render: (v) => (
         <Text fontSize="12px" color={Number(v || 0) >= 0 ? 'green.500' : 'red.500'}>
-          {Number(v || 0).toLocaleString(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 0 })}
+          {formatMoney(Number(v || 0), currency, { maximumFractionDigits: 0 })}
         </Text>
       ),
       width: '160px',

--- a/frontend/src/pages/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio.tsx
@@ -6,6 +6,8 @@ import SortableTable, { type Column } from '../components/SortableTable';
 import FinvizHeatMap from '../components/charts/FinvizHeatMap';
 import AccountFilterWrapper from '../components/ui/AccountFilterWrapper';
 import { transformPortfolioToAccounts } from '../hooks/useAccountFilter';
+import { useUserPreferences } from '../hooks/useUserPreferences';
+import { formatMoney } from '../utils/format';
 
 type AnyPos = any;
 
@@ -18,6 +20,7 @@ const Portfolio: React.FC = () => {
   const q = usePortfolio();
   const data = (q.data as any) || {};
   const accounts = transformPortfolioToAccounts(data);
+  const { currency } = useUserPreferences();
 
   const positions: AnyPos[] = React.useMemo(() => {
     const accs = Object.values<any>(data?.accounts || {});
@@ -76,7 +79,7 @@ const Portfolio: React.FC = () => {
       isNumeric: true,
       render: (v) => (
         <Text fontSize="12px" color="fg.muted">
-          {Number(v || 0).toLocaleString(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 0 })}
+          {formatMoney(Number(v || 0), currency, { maximumFractionDigits: 0 })}
         </Text>
       ),
       width: '160px',
@@ -90,7 +93,7 @@ const Portfolio: React.FC = () => {
       isNumeric: true,
       render: (v) => (
         <Text fontSize="12px" color={Number(v || 0) >= 0 ? 'green.500' : 'red.500'}>
-          {Number(v || 0).toLocaleString(undefined, { style: 'currency', currency: 'USD', maximumFractionDigits: 0 })}
+          {formatMoney(Number(v || 0), currency, { maximumFractionDigits: 0 })}
         </Text>
       ),
       width: '160px',

--- a/frontend/src/pages/SettingsPreferences.tsx
+++ b/frontend/src/pages/SettingsPreferences.tsx
@@ -84,9 +84,9 @@ const SettingsPreferences: React.FC = () => {
                   fontSize: 12,
                   padding: '8px 10px',
                   borderRadius: 10,
-                  border: '1px solid rgba(255,255,255,0.14)',
-                  background: 'var(--chakra-colors-bg-input, #0b1220)',
-                  color: 'var(--chakra-colors-fg-default, #e5e7eb)',
+                  border: '1px solid var(--chakra-colors-border-subtle)',
+                  background: 'var(--chakra-colors-bg-input)',
+                  color: 'var(--chakra-colors-fg-default)',
                 }}
               >
                 <option value="system">Use system preference</option>
@@ -105,9 +105,9 @@ const SettingsPreferences: React.FC = () => {
                   fontSize: 12,
                   padding: '8px 10px',
                   borderRadius: 10,
-                  border: '1px solid rgba(255,255,255,0.14)',
-                  background: 'var(--chakra-colors-bg-input, #0b1220)',
-                  color: 'var(--chakra-colors-fg-default, #e5e7eb)',
+                  border: '1px solid var(--chakra-colors-border-subtle)',
+                  background: 'var(--chakra-colors-bg-input)',
+                  color: 'var(--chakra-colors-fg-default)',
                 }}
               >
                 <option value="comfortable">Comfortable</option>
@@ -131,9 +131,9 @@ const SettingsPreferences: React.FC = () => {
                     fontSize: 12,
                     padding: '8px 10px',
                     borderRadius: 10,
-                    border: '1px solid rgba(255,255,255,0.14)',
-                    background: 'var(--chakra-colors-bg-input, #0b1220)',
-                    color: 'var(--chakra-colors-fg-default, #e5e7eb)',
+                    border: '1px solid var(--chakra-colors-border-subtle)',
+                    background: 'var(--chakra-colors-bg-input)',
+                    color: 'var(--chakra-colors-fg-default)',
                   }}
                 >
                   {timezones.map((tz) => (

--- a/frontend/src/pages/__tests__/AdminDashboardCoverageRefresh.test.tsx
+++ b/frontend/src/pages/__tests__/AdminDashboardCoverageRefresh.test.tsx
@@ -9,6 +9,14 @@ import { renderWithProviders } from '../../test/render';
 const apiPost = vi.fn().mockResolvedValue({ data: { task_id: 'task-123' } });
 const apiGet = vi.fn().mockResolvedValue({ data: {} });
 
+vi.mock('../../hooks/useUserPreferences', () => ({
+  useUserPreferences: () => ({
+    currency: 'USD',
+    timezone: 'UTC',
+    tableDensity: 'comfortable',
+  }),
+}));
+
 vi.mock('../../services/api', () => {
   return {
     default: {

--- a/frontend/src/pages/__tests__/AdminJobs.test.tsx
+++ b/frontend/src/pages/__tests__/AdminJobs.test.tsx
@@ -7,6 +7,14 @@ import { renderWithProviders } from '../../test/render';
 
 const apiGet = vi.fn();
 
+vi.mock('../../hooks/useUserPreferences', () => ({
+  useUserPreferences: () => ({
+    currency: 'USD',
+    timezone: 'UTC',
+    tableDensity: 'comfortable',
+  }),
+}));
+
 vi.mock('../../services/api', () => {
   return {
     default: {

--- a/frontend/src/theme/system.ts
+++ b/frontend/src/theme/system.ts
@@ -81,6 +81,7 @@ export const system = createSystem(
               _dark: "#070B12",
             },
           },
+          // Slightly elevated surface behind cards/tables.
           "bg.panel": {
             value: {
               _light: "white",
@@ -91,6 +92,32 @@ export const system = createSystem(
             value: {
               _light: "white",
               _dark: "rgba(17, 24, 39, 0.72)",
+            },
+          },
+          // Subtle interactive surfaces (hover/selected states).
+          "bg.muted": {
+            value: {
+              _light: "rgba(15, 23, 42, 0.05)",
+              _dark: "rgba(255, 255, 255, 0.06)",
+            },
+          },
+          "bg.subtle": {
+            value: {
+              _light: "rgba(15, 23, 42, 0.08)",
+              _dark: "rgba(255, 255, 255, 0.10)",
+            },
+          },
+          // Layout surfaces (header/sidebar) so app chrome theme stays coherent.
+          "bg.header": {
+            value: {
+              _light: "white",
+              _dark: "#0B1220",
+            },
+          },
+          "bg.sidebar": {
+            value: {
+              _light: "white",
+              _dark: "#0B1220",
             },
           },
           "bg.input": {

--- a/frontend/src/utils/__tests__/format.test.ts
+++ b/frontend/src/utils/__tests__/format.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { formatDateTime, formatMoney, formatTime } from '../format';
+
+describe('formatMoney', () => {
+  it('formats currency with requested precision', () => {
+    expect(formatMoney(1234.56, 'USD', { maximumFractionDigits: 0 })).toBe('$1,235');
+    expect(formatMoney(1234.56, 'USD', { minimumFractionDigits: 2, maximumFractionDigits: 2 })).toBe('$1,234.56');
+  });
+
+  it('does not throw on unknown/invalid currency codes', () => {
+    expect(() => formatMoney(10, 'ZZZ', { maximumFractionDigits: 0 })).not.toThrow();
+    // Some runtimes format unknown codes as "ZZZ 10"; others may throw and be caught as USD.
+    expect(formatMoney(10, 'ZZZ', { maximumFractionDigits: 0 })).toMatch(/10/);
+  });
+});
+
+describe('formatDateTime / formatTime', () => {
+  it('formats in requested timezone when possible', () => {
+    const iso = '2026-01-07T08:50:30.000Z';
+    const utc = formatDateTime(iso, 'UTC');
+    const ny = formatDateTime(iso, 'America/New_York');
+    expect(utc).toContain('01/07/2026');
+    expect(ny).toContain('01/07/2026');
+    // In January, New York should differ from UTC.
+    expect(ny).not.toBe(utc);
+  });
+
+  it('formats time-only in requested timezone when possible', () => {
+    const iso = '2026-01-07T08:50:30.000Z';
+    const utc = formatTime(iso, 'UTC');
+    const ny = formatTime(iso, 'America/New_York');
+    expect(utc).toMatch(/\d{2}:\d{2}:\d{2}/);
+    expect(ny).toMatch(/\d{2}:\d{2}:\d{2}/);
+    expect(ny).not.toBe(utc);
+  });
+});
+
+

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,0 +1,94 @@
+export type MoneyFormatOptions = {
+  maximumFractionDigits?: number;
+  minimumFractionDigits?: number;
+};
+
+function safeDate(value: string | number | Date): Date | null {
+  const d = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function safeCurrency(code: string | undefined | null): string {
+  const c = String(code || "USD").trim().toUpperCase();
+  if (c.length !== 3) return "USD";
+  return c;
+}
+
+export function formatMoney(
+  amount: number | string | null | undefined,
+  currency: string | undefined | null,
+  opts: MoneyFormatOptions = {}
+): string {
+  const n = Number(amount ?? 0);
+  const cur = safeCurrency(currency);
+  const maximumFractionDigits = opts.maximumFractionDigits ?? 2;
+  const minimumFractionDigits = opts.minimumFractionDigits ?? 0;
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: cur,
+      maximumFractionDigits,
+      minimumFractionDigits,
+    }).format(Number.isFinite(n) ? n : 0);
+  } catch {
+    // If currency code is invalid for this runtime, fall back to USD.
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits,
+      minimumFractionDigits,
+    }).format(Number.isFinite(n) ? n : 0);
+  }
+}
+
+export function formatDateTime(
+  value: string | number | Date | null | undefined,
+  timezone: string | undefined | null
+): string {
+  if (value == null) return "—";
+  const d = safeDate(value);
+  if (!d) return "—";
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone || undefined,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    }).format(d);
+  } catch {
+    return new Intl.DateTimeFormat("en-US", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    }).format(d);
+  }
+}
+
+export function formatTime(
+  value: string | number | Date | null | undefined,
+  timezone: string | undefined | null
+): string {
+  if (value == null) return "—";
+  const d = safeDate(value);
+  if (!d) return "—";
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone || undefined,
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    }).format(d);
+  } catch {
+    return new Intl.DateTimeFormat("en-US", {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    }).format(d);
+  }
+}
+
+


### PR DESCRIPTION
### Summary\n- Fix light mode styling by switching app chrome + selects to semantic tokens/CSS variables\n- Persist + apply user preferences (theme/currency/timezone/table density) across key pages\n- Add format utilities + focused tests\n\n### Testing\n- make frontend-test