### PR TITLE
perf(market-data): speed up daily backfill

### DIFF
--- a/backend/api/routes/market_data.py
+++ b/backend/api/routes/market_data.py
@@ -437,10 +437,13 @@ async def post_update_tracked(
 
 @router.post("/backfill/index-universe")
 async def post_backfill_index_universe(
-    batch_size: int = Query(20, ge=5, le=100),
+    batch_size: int | None = Query(None, ge=5, le=500),
     user: User | None = Depends(get_optional_user),
 ) -> Dict[str, Any]:
     """Bootstrap helper: enqueue batched backfill for SP500/NASDAQ100/DOW30 constituents."""
+    if batch_size is None:
+        policy = str(getattr(settings, "MARKET_PROVIDER_POLICY", "paid")).lower()
+        batch_size = 100 if policy == "paid" else 20
     return _enqueue_task(backfill_index_universe, batch_size=batch_size)
 
 

--- a/backend/config.py
+++ b/backend/config.py
@@ -88,6 +88,15 @@ class Settings(BaseSettings):
     MARKET_PROVIDER_POLICY: str = "paid"
     # Default cache TTL for market-data service (seconds)
     MARKET_DATA_CACHE_TTL: int = 300
+    # Daily backfill throughput controls (safe defaults; override via env in infra/env.dev)
+    # - paid: higher concurrency (FMP is the primary provider)
+    # - free: lower concurrency (avoid hammering free-tier sources)
+    MARKET_BACKFILL_CONCURRENCY_PAID: int = 25
+    MARKET_BACKFILL_CONCURRENCY_FREE: int = 5
+    MARKET_BACKFILL_CONCURRENCY_MAX: int = 100
+    # Provider retry/backoff (applies to transient provider failures like 429/5xx)
+    MARKET_BACKFILL_RETRY_ATTEMPTS: int = 6
+    MARKET_BACKFILL_RETRY_MAX_DELAY_SECONDS: float = 60.0
     # Toggle whether Coverage/Tracked sections are visible to all authenticated users
     MARKET_DATA_SECTION_PUBLIC: bool = False
 

--- a/backend/tests/test_market_data_backfill_speed.py
+++ b/backend/tests/test_market_data_backfill_speed.py
@@ -1,0 +1,70 @@
+import asyncio
+import pandas as pd
+from datetime import datetime, timedelta
+
+import pytest
+
+from backend.services.market.market_data_service import MarketDataService, market_data_service
+
+
+def _make_df(days: int = 5) -> pd.DataFrame:
+    now = datetime.utcnow().replace(microsecond=0)
+    dates = [now - timedelta(days=i) for i in range(days)][::-1]
+    df = pd.DataFrame(
+        [{"Open": 1.0, "High": 1.0, "Low": 1.0, "Close": 1.0, "Volume": 1} for _ in dates],
+        index=pd.DatetimeIndex(dates),
+    )
+    return df
+
+
+@pytest.mark.asyncio
+async def test_call_blocking_with_retries_backoff_on_429(monkeypatch):
+    svc = MarketDataService()
+    sleeps: list[float] = []
+
+    async def fake_sleep(delay: float):
+        sleeps.append(float(delay))
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    class RateLimitExc(Exception):
+        status_code = 429
+
+    calls = {"n": 0}
+
+    def flaky():
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise RateLimitExc("429")
+        return "ok"
+
+    out = await svc._call_blocking_with_retries(flaky, attempts=5, max_delay_seconds=1.0)
+    assert out == "ok"
+    assert calls["n"] == 3
+    # Should have backed off at least once
+    assert len(sleeps) >= 2
+
+
+def test_persist_price_bars_bulk_upsert_still_delta_only(db_session):
+    sym = "BULKTEST"
+    df = _make_df(days=3)
+    inserted_1 = market_data_service.persist_price_bars(
+        db_session, sym, df.iloc[:1], interval="1d", data_source="unit_test", is_adjusted=True
+    )
+    assert inserted_1 == 1
+    from backend.models import PriceData
+
+    last_date = (
+        db_session.query(PriceData.date)
+        .filter(PriceData.symbol == sym, PriceData.interval == "1d")
+        .order_by(PriceData.date.desc())
+        .limit(1)
+        .scalar()
+    )
+    assert last_date is not None
+    inserted_2 = market_data_service.persist_price_bars(
+        db_session, sym, df, interval="1d", data_source="unit_test", is_adjusted=True, delta_after=last_date
+    )
+    assert inserted_2 == 2
+
+


### PR DESCRIPTION
### What\n- Add retry/backoff + thread-offloading for blocking provider calls (FMP/YF/TD)\n- Make daily backfill concurrent for tracked universe (paid/free concurrency knobs)\n- Speed up DB persistence via bulk upsert for price bars\n- Make index-universe backfill default batch size policy-aware (paid=100, free=20)\n\n### Config\n- MARKET_BACKFILL_CONCURRENCY_PAID (default 25)\n- MARKET_BACKFILL_CONCURRENCY_FREE (default 5)\n- MARKET_BACKFILL_CONCURRENCY_MAX (default 100)\n- MARKET_BACKFILL_RETRY_ATTEMPTS (default 6)\n- MARKET_BACKFILL_RETRY_MAX_DELAY_SECONDS (default 60)\n\n### Testing\n- make test