### PR TITLE
feat(admin): daily coverage histogram strip

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -102,6 +102,10 @@ class Settings(BaseSettings):
     # Coverage UI sampling only (must NOT affect correctness/backfills).
     # Number of stale symbols to include in API/UI sample lists (full counts are computed separately).
     COVERAGE_STALE_SAMPLE: int = 200
+    # Coverage fill-by-date lookback (calendar days). Used for daily.fill_by_date and snapshot_fill_by_date series.
+    COVERAGE_FILL_LOOKBACK_DAYS: int = 90
+    # How many *trading days* to render in the UI histogram (frontend reads this from /market-data/coverage meta).
+    COVERAGE_FILL_TRADING_DAYS_WINDOW: int = 50
 
     # Source of truth should be runtime environment variables injected by Docker Compose
     # (`infra/env.dev` via Makefile). We keep optional env-file support only when explicitly

--- a/frontend/src/components/coverage/CoverageSummaryCard.tsx
+++ b/frontend/src/components/coverage/CoverageSummaryCard.tsx
@@ -11,6 +11,7 @@ import type {
 export interface CoverageSummaryCardProps {
   hero: CoverageHeroMeta;
   status?: any;
+  showUpdated?: boolean;
   children?: React.ReactNode;
 }
 
@@ -18,7 +19,11 @@ export interface CoverageSummaryCardProps {
  * Read-only coverage summary container.
  * Keep this dependency-light so CI doesn't depend on chart libs/DOM quirks.
  */
-export const CoverageSummaryCard: React.FC<CoverageSummaryCardProps> = ({ hero, children }) => {
+export const CoverageSummaryCard: React.FC<CoverageSummaryCardProps> = ({
+  hero,
+  showUpdated = true,
+  children,
+}) => {
   const label = String(hero.statusLabel || '').toUpperCase() || '—';
   const palette =
     hero.statusColor === 'green'
@@ -35,9 +40,11 @@ export const CoverageSummaryCard: React.FC<CoverageSummaryCardProps> = ({ hero, 
           <HStack justify="space-between" align="start" gap={3} flexWrap="wrap">
             <Box>
               <Heading size="sm">Coverage</Heading>
-              <Text fontSize="xs" color="fg.muted">
-                Updated {hero.updatedRelative} ({hero.updatedDisplay})
-              </Text>
+              {showUpdated && hero && hero.updatedRelative && hero.updatedDisplay ? (
+                <Text fontSize="xs" color="fg.muted">
+                  Updated {hero.updatedRelative} ({hero.updatedDisplay})
+                </Text>
+              ) : null}
             </Box>
             <Badge variant="subtle" colorPalette={palette}>
               {label}

--- a/frontend/src/components/coverage/CoverageSummaryCard.tsx
+++ b/frontend/src/components/coverage/CoverageSummaryCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Heading, Stack, Text } from '@chakra-ui/react';
+import { Badge, Box, Heading, HStack, Stack, Text } from '@chakra-ui/react';
 import type {
   CoverageAction,
   CoverageBucketGroup,
@@ -19,20 +19,40 @@ export interface CoverageSummaryCardProps {
  * Keep this dependency-light so CI doesn't depend on chart libs/DOM quirks.
  */
 export const CoverageSummaryCard: React.FC<CoverageSummaryCardProps> = ({ hero, children }) => {
+  const label = String(hero.statusLabel || '').toUpperCase() || '—';
+  const palette =
+    hero.statusColor === 'green'
+      ? 'green'
+      : hero.statusColor === 'yellow'
+        ? 'orange'
+        : hero.statusColor === 'red'
+          ? 'red'
+          : 'gray';
   return (
-    <Box borderWidth="1px" borderRadius="md" p={4}>
+    <Box borderWidth="1px" borderColor="border.subtle" borderRadius="lg" p={4} bg="bg.card">
       <Stack gap={3}>
         <Box>
-          <Heading size="sm">Coverage Status</Heading>
-          <Text fontSize="sm" color="gray.400">
-            {hero.statusLabel} · Updated {hero.updatedRelative} ({hero.updatedDisplay})
-          </Text>
-          <Text mt={1}>{hero.summary}</Text>
+          <HStack justify="space-between" align="start" gap={3} flexWrap="wrap">
+            <Box>
+              <Heading size="sm">Coverage</Heading>
+              <Text fontSize="xs" color="fg.muted">
+                Updated {hero.updatedRelative} ({hero.updatedDisplay})
+              </Text>
+            </Box>
+            <Badge variant="subtle" colorPalette={palette}>
+              {label}
+            </Badge>
+          </HStack>
+          {hero.summary ? (
+            <Text mt={1} fontSize="sm" color="fg.muted">
+              {hero.summary}
+            </Text>
+          ) : null}
           {hero.warningBanner ? (
-            <Box mt={2} borderWidth="1px" borderRadius="md" p={3}>
+            <Box mt={2} borderWidth="1px" borderColor="border.subtle" borderRadius="md" p={3} bg="bg.muted">
               <Text fontWeight="semibold">{hero.warningBanner.title}</Text>
               {hero.warningBanner.description ? (
-                <Text fontSize="sm" color="gray.400">
+                <Text fontSize="sm" color="fg.muted">
                   {hero.warningBanner.description}
                 </Text>
               ) : null}

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -213,32 +213,32 @@ const AdminDashboard: React.FC = () => {
 
     return (
       <Box mt={2}>
-        <HStack
-          align="end"
-          gap={1}
-          h={`${barMaxH}px`}
+        <Box
           borderRadius="md"
           borderWidth="1px"
           borderColor="border.subtle"
           bg="bg.card"
           px={2}
           py={2}
+          overflow="hidden"
         >
-          {bars.map((r) => {
-            const pct = pctFor(r.count);
-            const h = Math.max(2, Math.round((pct / 100) * barMaxH));
-            return (
-              <Box
-                key={r.date}
-                w="10px"
-                h={`${h}px`}
-                borderRadius="sm"
-                bg={colorForPct(pct)}
-                title={`${r.date}: ${r.count}/${total} (${Math.round(pct * 10) / 10}%)`}
-              />
-            );
-          })}
-        </HStack>
+          <HStack align="end" gap={1} h={`${barMaxH}px`}>
+            {bars.map((r) => {
+              const pct = pctFor(r.count);
+              const h = Math.max(2, Math.round((pct / 100) * barMaxH));
+              return (
+                <Box
+                  key={r.date}
+                  w="10px"
+                  h={`${h}px`}
+                  borderRadius="sm"
+                  bg={colorForPct(pct)}
+                  title={`${r.date}: ${r.count}/${total} (${Math.round(pct * 10) / 10}%)`}
+                />
+              );
+            })}
+          </HStack>
+        </Box>
         <Text mt={1} fontSize="xs" color="fg.muted">
           Histogram bars (daily): height + color represent % of symbols whose latest daily bar is that date.
         </Text>

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -405,7 +405,7 @@ const AdminDashboard: React.FC = () => {
                     Update Tracked
                   </Button>
                   <Button size="xs" variant="outline" onClick={() => void runNamedTask('recompute_indicators_universe', 'Recompute indicators')}>
-                    Generate Snapshots
+                    Recompute Indicators (Snapshots)
                   </Button>
                   <Button size="xs" variant="outline" onClick={() => void runNamedTask('record_daily_history', 'Record history')}>
                     Record History

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -213,7 +213,10 @@ const AdminDashboard: React.FC = () => {
 
     // Trading-day series: use the last N observed dates in fill_by_date.
     // This naturally excludes weekends/holidays (no OHLCV rows expected) and avoids confusing gaps.
-    const windowDays = 50;
+    const windowDays = Math.max(
+      1,
+      Number((coverage as any)?.meta?.fill_trading_days_window ?? 50),
+    );
     const bars: Array<{ date: string; symbol_count: number; pct_of_universe: number }> = rows
       .slice() // newest-first
       .reverse() // oldest-first
@@ -236,7 +239,7 @@ const AdminDashboard: React.FC = () => {
           overflowX="auto"
           overflowY="hidden"
         >
-          <HStack align="end" gap={1} h={`${barMaxH}px`} minW="max-content">
+          <HStack align="end" gap={1} h={`${barMaxH}px`} w="full">
             {bars.map((r) => {
               const pct = pctFor(r);
               const h = Math.max(2, Math.round((pct / 100) * barMaxH));
@@ -253,8 +256,13 @@ const AdminDashboard: React.FC = () => {
                       ? 'orange.500'
                       : 'red.500';
               return (
-                <Box key={r.date} w="10px" title={`${r.date}: ${r.symbol_count}/${total} (${Math.round(pct * 10) / 10}%)`}>
-                  <Box w="10px" h={`${h}px`} borderRadius="sm" bg={colorForPct(pct)} />
+                <Box
+                  key={r.date}
+                  flex="1 0 0"
+                  minW="6px"
+                  title={`${r.date}: ${r.symbol_count}/${total} (${Math.round(pct * 10) / 10}%)`}
+                >
+                  <Box w="full" h={`${h}px`} borderRadius="sm" bg={colorForPct(pct)} />
                   <Box
                     mt="2px"
                     mx="auto"

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -198,7 +198,7 @@ const AdminDashboard: React.FC = () => {
     if (!backfill5mEnabled && hero?.staleCounts?.daily === 0 && hero?.staleCounts?.m5 > 0) {
       return {
         ...hero,
-        summary: 'Daily coverage OK • 5m disabled (ignored).',
+        summary: '5m is disabled (ignored for status).',
       };
     }
     return hero;
@@ -303,7 +303,7 @@ const AdminDashboard: React.FC = () => {
       <Heading size="md" mb={4}>Admin Dashboard</Heading>
 
       {coverage && (
-        <CoverageSummaryCard hero={heroEffective} status={coverage.status}>
+        <CoverageSummaryCard hero={heroEffective} status={coverage.status} showUpdated={false}>
           <CoverageKpiGrid kpis={kpis} variant="stat" />
           <CoverageTrendGrid sparkline={sparkline} />
           <CoverageBucketsGrid groups={hero?.buckets || []} />

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -1,5 +1,17 @@
 import React from 'react';
-import { Box, Heading, Button, Text, HStack, VStack, Badge } from '@chakra-ui/react';
+import {
+  Box,
+  Heading,
+  Button,
+  Text,
+  HStack,
+  VStack,
+  Badge,
+  TooltipRoot,
+  TooltipTrigger,
+  TooltipPositioner,
+  TooltipContent,
+} from '@chakra-ui/react';
 import toast from 'react-hot-toast';
 import api from '../services/api';
 import { triggerTaskByName } from '../utils/taskActions';
@@ -189,7 +201,7 @@ const AdminDashboard: React.FC = () => {
     if (!backfill5mEnabled && hero?.staleCounts?.daily === 0 && hero?.staleCounts?.m5 > 0) {
       return {
         ...hero,
-        summary: 'Daily coverage is green. 5m is disabled (ignored for status).',
+        summary: 'Daily coverage OK • 5m disabled (ignored).',
       };
     }
     return hero;
@@ -324,16 +336,31 @@ const AdminDashboard: React.FC = () => {
             </Box>
           ) : null}
           <Box mt={3} display="flex" alignItems="center" justifyContent="space-between" gap={3} flexWrap="wrap">
-            <Box>
-              <HStack gap={2} flexWrap="wrap">
-                <Badge variant="subtle">Source: {String(coverage?.meta?.source || '—')}</Badge>
-                <Badge variant="subtle">Last refresh: {formatDateTime(coverage?.meta?.updated_at, timezone)}</Badge>
-                <Badge variant="subtle">Monitor: {fmtLastRun('monitor_coverage_health')}</Badge>
-                <Badge variant="subtle">Restore: {fmtLastRun('bootstrap_daily_coverage_tracked')}</Badge>
-              </HStack>
-            </Box>
+            <HStack gap={2} flexWrap="wrap">
+              <Badge variant="subtle">Source: {String(coverage?.meta?.source || '—')}</Badge>
+              <Badge variant="subtle">Refreshed: {formatDateTime(coverage?.meta?.updated_at, timezone)}</Badge>
+              <TooltipRoot>
+                <TooltipTrigger asChild>
+                  <Badge variant="subtle" cursor="help">
+                    Runs: monitor/restore
+                  </Badge>
+                </TooltipTrigger>
+                <TooltipPositioner>
+                  <TooltipContent>
+                    <Box>
+                      <Text fontSize="xs" color="fg.muted">
+                        Monitor: {fmtLastRun('monitor_coverage_health')}
+                      </Text>
+                      <Text fontSize="xs" color="fg.muted">
+                        Restore: {fmtLastRun('bootstrap_daily_coverage_tracked')}
+                      </Text>
+                    </Box>
+                  </TooltipContent>
+                </TooltipPositioner>
+              </TooltipRoot>
+            </HStack>
             <Button size="sm" variant="outline" loading={refreshingCoverage} onClick={() => void refreshCoverageNow('manual')}>
-              Refresh coverage now
+              Refresh coverage
             </Button>
           </Box>
           <Box mt={3} display="flex" alignItems="center" gap={3}>
@@ -378,7 +405,7 @@ const AdminDashboard: React.FC = () => {
                     Update Tracked
                   </Button>
                   <Button size="xs" variant="outline" onClick={() => void runNamedTask('recompute_indicators_universe', 'Recompute indicators')}>
-                    Recompute Indicators
+                    Generate Snapshots
                   </Button>
                   <Button size="xs" variant="outline" onClick={() => void runNamedTask('record_daily_history', 'Record history')}>
                     Record History

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -310,18 +310,9 @@ const AdminDashboard: React.FC = () => {
                 </Badge>
               </HStack>
               {dailyHistogram}
-              <VStack align="stretch" gap={1.5} mt={3}>
-                {dailyFillDist.rows.slice(0, 8).map((row) => (
-                  <HStack key={row.date} justify="space-between">
-                    <Text fontSize="xs" color="fg.muted">
-                      {row.date}
-                    </Text>
-                    <Text fontSize="xs" color="fg.default">
-                      {row.symbol_count} ({Math.round(Number(row.pct_of_universe || 0) * 10) / 10}%)
-                    </Text>
-                  </HStack>
-                ))}
-              </VStack>
+              <Text mt={2} fontSize="xs" color="fg.muted">
+                Hover a bar to see date, filled symbols, fill %, and snapshot %.
+              </Text>
             </Box>
           ) : null}
           <Box mt={3} display="flex" alignItems="center" justifyContent="space-between" gap={3} flexWrap="wrap">

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -205,11 +205,18 @@ const AdminDashboard: React.FC = () => {
       return `hsl(${hue}, 70%, 45%)`;
     };
 
-    const maxBars = 28; // show last ~4 weeks of daily buckets by default
     const barMaxH = 36;
-    const bars = rows
-      .filter((r) => r.date !== 'none')
-      .slice(0, maxBars);
+    const countMap = new Map(rows.filter((r) => r.date !== 'none').map((r) => [r.date, r.count]));
+
+    // Build a continuous daily series from the 1st of the month (of the newest date) through newestDate.
+    // This makes month-to-date progress easy to read.
+    const newest = new Date(`${newestDate}T00:00:00Z`);
+    const start = new Date(Date.UTC(newest.getUTCFullYear(), newest.getUTCMonth(), 1));
+    const bars: Array<{ date: string; count: number }> = [];
+    for (let d = new Date(start); d.getTime() <= newest.getTime(); d = new Date(d.getTime() + 86400000)) {
+      const dateStr = d.toISOString().slice(0, 10);
+      bars.push({ date: dateStr, count: countMap.get(dateStr) || 0 });
+    }
 
     return (
       <Box mt={2}>
@@ -240,7 +247,7 @@ const AdminDashboard: React.FC = () => {
           </HStack>
         </Box>
         <Text mt={1} fontSize="xs" color="fg.muted">
-          Histogram bars (daily): height + color represent % of symbols whose latest daily bar is that date.
+          Histogram bars (daily, month-to-date): height + color represent % of symbols whose latest daily bar is that date.
         </Text>
       </Box>
     );

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -7,10 +7,7 @@ import {
   HStack,
   VStack,
   Badge,
-  TooltipRoot,
-  TooltipTrigger,
-  TooltipPositioner,
-  TooltipContent,
+  Tooltip,
 } from '@chakra-ui/react';
 import toast from 'react-hot-toast';
 import api from '../services/api';
@@ -339,14 +336,14 @@ const AdminDashboard: React.FC = () => {
             <HStack gap={2} flexWrap="wrap">
               <Badge variant="subtle">Source: {String(coverage?.meta?.source || '—')}</Badge>
               <Badge variant="subtle">Refreshed: {formatDateTime(coverage?.meta?.updated_at, timezone)}</Badge>
-              <TooltipRoot>
-                <TooltipTrigger asChild>
+              <Tooltip.Root openDelay={200} positioning={{ placement: 'top' }}>
+                <Tooltip.Trigger asChild>
                   <Badge variant="subtle" cursor="help">
                     Runs: monitor/restore
                   </Badge>
-                </TooltipTrigger>
-                <TooltipPositioner>
-                  <TooltipContent>
+                </Tooltip.Trigger>
+                <Tooltip.Positioner>
+                  <Tooltip.Content>
                     <Box>
                       <Text fontSize="xs" color="fg.muted">
                         Monitor: {fmtLastRun('monitor_coverage_health')}
@@ -355,9 +352,9 @@ const AdminDashboard: React.FC = () => {
                         Restore: {fmtLastRun('bootstrap_daily_coverage_tracked')}
                       </Text>
                     </Box>
-                  </TooltipContent>
-                </TooltipPositioner>
-              </TooltipRoot>
+                  </Tooltip.Content>
+                </Tooltip.Positioner>
+              </Tooltip.Root>
             </HStack>
             <Button size="sm" variant="outline" loading={refreshingCoverage} onClick={() => void refreshCoverageNow('manual')}>
               Refresh coverage
@@ -405,7 +402,7 @@ const AdminDashboard: React.FC = () => {
                     Update Tracked
                   </Button>
                   <Button size="xs" variant="outline" onClick={() => void runNamedTask('recompute_indicators_universe', 'Recompute indicators')}>
-                    Recompute Indicators (Snapshots)
+                    Recompute Indicators (Market Snapshot)
                   </Button>
                   <Button size="xs" variant="outline" onClick={() => void runNamedTask('record_daily_history', 'Record history')}>
                     Record History

--- a/frontend/src/pages/AdminDashboard.tsx
+++ b/frontend/src/pages/AdminDashboard.tsx
@@ -208,10 +208,11 @@ const AdminDashboard: React.FC = () => {
     const barMaxH = 36;
     const countMap = new Map(rows.filter((r) => r.date !== 'none').map((r) => [r.date, r.count]));
 
-    // Build a continuous daily series from the 1st of the month (of the newest date) through newestDate.
-    // This makes month-to-date progress easy to read.
+    // Build a continuous daily series over a rolling window (last ~30+ days).
+    // This matches the common “last N days” operator mental model.
     const newest = new Date(`${newestDate}T00:00:00Z`);
-    const start = new Date(Date.UTC(newest.getUTCFullYear(), newest.getUTCMonth(), 1));
+    const windowDays = 35;
+    const start = new Date(newest.getTime() - (windowDays - 1) * 86400000);
     const bars: Array<{ date: string; count: number }> = [];
     for (let d = new Date(start); d.getTime() <= newest.getTime(); d = new Date(d.getTime() + 86400000)) {
       const dateStr = d.toISOString().slice(0, 10);
@@ -247,7 +248,7 @@ const AdminDashboard: React.FC = () => {
           </HStack>
         </Box>
         <Text mt={1} fontSize="xs" color="fg.muted">
-          Histogram bars (daily, month-to-date): height + color represent % of symbols whose latest daily bar is that date.
+          Histogram bars (daily, last {windowDays} days): height + color represent % of symbols whose latest daily bar is that date.
         </Text>
       </Box>
     );

--- a/frontend/src/pages/AdminJobs.tsx
+++ b/frontend/src/pages/AdminJobs.tsx
@@ -138,7 +138,14 @@ const AdminJobs: React.FC = () => {
           Reload
         </Button>
       </HStack>
-      <Box w="full" borderWidth="1px" borderColor="border.subtle" borderRadius="xl" bg="bg.card">
+      <Box
+        w="full"
+        borderWidth="1px"
+        borderColor="border.subtle"
+        borderRadius="lg"
+        bg="bg.card"
+        overflow="hidden"
+      >
         <SortableTable
           data={data?.jobs || []}
           columns={

--- a/frontend/src/pages/AdminSchedules.tsx
+++ b/frontend/src/pages/AdminSchedules.tsx
@@ -137,7 +137,14 @@ const AdminSchedules: React.FC = () => {
         </HStack>
       </HStack>
 
-      <Box w="full" borderWidth="1px" borderColor="border.subtle" borderRadius="xl" bg="bg.card">
+      <Box
+        w="full"
+        borderWidth="1px"
+        borderColor="border.subtle"
+        borderRadius="lg"
+        bg="bg.card"
+        overflow="hidden"
+      >
         <SortableTable
           data={data?.schedules || []}
           columns={

--- a/frontend/src/pages/__tests__/AdminDashboardCoverageRefresh.test.tsx
+++ b/frontend/src/pages/__tests__/AdminDashboardCoverageRefresh.test.tsx
@@ -46,12 +46,20 @@ vi.mock('../../hooks/useCoverageSnapshot', () => {
           backfill_5m_enabled: true,
         },
         status: { label: 'degraded', summary: 'test', daily_pct: 0, m5_pct: 0, stale_daily: 1, stale_m5: 0 },
+        symbols: 3,
         daily: {
           last: {
             A: '2026-01-08T00:00:00Z',
             B: '2026-01-08T00:00:00Z',
             C: '2026-01-02T00:00:00Z',
           },
+          fill_by_date: [
+            { date: '2026-01-08', symbol_count: 2, pct_of_universe: 66.7 },
+            { date: '2026-01-02', symbol_count: 1, pct_of_universe: 33.3 },
+          ],
+          snapshot_fill_by_date: [
+            { date: '2026-01-08', symbol_count: 2, pct_of_universe: 66.7 },
+          ],
         },
       },
       refresh: vi.fn(),
@@ -102,9 +110,9 @@ describe('AdminDashboard coverage refresh', () => {
     expect(stale.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('renders daily last-bar distribution', async () => {
+  it('renders daily fill-by-date distribution', async () => {
     renderWithProviders(<AdminDashboard />, { route: '/settings/admin/dashboard' });
-    const blocks = await screen.findAllByText(/Daily last-bar distribution/i);
+    const blocks = await screen.findAllByText(/Daily fill by date/i);
     expect(blocks.length).toBeGreaterThanOrEqual(1);
     const newest = await screen.findAllByText(/Newest date: 2026-01-08/i);
     expect(newest.length).toBeGreaterThanOrEqual(1);

--- a/frontend/src/pages/__tests__/AdminDashboardCoverageRefresh.test.tsx
+++ b/frontend/src/pages/__tests__/AdminDashboardCoverageRefresh.test.tsx
@@ -116,8 +116,8 @@ describe('AdminDashboard coverage refresh', () => {
     expect(blocks.length).toBeGreaterThanOrEqual(1);
     const newest = await screen.findAllByText(/Newest date: 2026-01-08/i);
     expect(newest.length).toBeGreaterThanOrEqual(1);
-    // Distribution list includes the older date too (not just newest).
-    expect(document.body.textContent || '').toContain('2026-01-02');
+    // Tooltip-only details: ensure hint is present.
+    expect(document.body.textContent || '').toContain('Hover a bar to see date');
   });
 });
 

--- a/frontend/src/pages/__tests__/AdminDashboardCoverageRefresh.test.tsx
+++ b/frontend/src/pages/__tests__/AdminDashboardCoverageRefresh.test.tsx
@@ -96,7 +96,7 @@ describe('AdminDashboard coverage refresh', () => {
   it('allows manual refresh via button', async () => {
     const user = userEvent.setup();
     renderWithProviders(<AdminDashboard />, { route: '/settings/admin/dashboard' });
-    const btn = (await screen.findAllByRole('button', { name: /refresh coverage now/i }))[0];
+    const btn = (await screen.findAllByRole('button', { name: /refresh coverage/i }))[0];
     await user.click(btn);
     expect(apiPost).toHaveBeenCalledWith('/market-data/admin/coverage/refresh');
     expect(apiPost.mock.calls.filter((c) => c[0] === '/market-data/admin/coverage/refresh').length).toBeGreaterThanOrEqual(2);

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -4,7 +4,15 @@ export type MoneyFormatOptions = {
 };
 
 function safeDate(value: string | number | Date): Date | null {
-  const d = value instanceof Date ? value : new Date(value);
+  // Backend timestamps should be UTC. If we get an ISO-like string without a timezone,
+  // normalize it to UTC by appending "Z" so the browser doesn't interpret it as local time.
+  const normalized =
+    typeof value === "string" &&
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?$/.test(value) &&
+    !/[zZ]$/.test(value)
+      ? `${value}Z`
+      : value;
+  const d = normalized instanceof Date ? normalized : new Date(normalized);
   return Number.isNaN(d.getTime()) ? null : d;
 }
 


### PR DESCRIPTION
### What\n- Replace the daily distribution progress bar with a day-bucket histogram strip (green→red by age)\n- Keep the textual newest-date distribution + counts\n- Clean up the noisy metadata line into compact badges\n- Suppress 5m-missing hero messaging when 5m is disabled\n\n### Testing\n- make test-all