### PR TITLE
chore(deps): bump black to 26.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ redis==7.1.0
 celery-redbeat==2.3.3
 
 # Linters & Dev
-black==24.10.0
+black==26.1.0
 ruff==0.14.13
 
 # APM/Monitoring


### PR DESCRIPTION
## Summary
- bump black to 26.1.0 on top of latest main

## Test plan
- CI
