### PR TITLE
render: fix static site blueprint

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -76,11 +76,12 @@ services:
           property: connectionString
     startCommand: celery -A backend.tasks.celery_app worker --loglevel=info
 
-  - type: static_site
+  - type: web
     name: axiomfolio-frontend
+    runtime: static
     autoDeploy: false
     buildCommand: cd frontend && rm -rf node_modules package-lock.json && npm install && npm run build
-    publishPath: frontend/dist
+    staticPublishPath: frontend/dist
     envVars:
       - key: VITE_API_BASE_URL
         value: https://api.axiomfolio.com/api/v1


### PR DESCRIPTION
## Summary
- update frontend service to use `type: web` with `runtime: static`
- switch to `staticPublishPath` per Render blueprint spec

## Test plan
- Not run (Render blueprint validation)

Made with [Cursor](https://cursor.com)